### PR TITLE
Add per-app test configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,9 +187,9 @@ npm run allureReport
 11. For HTML Report generation execute below command , single static HTML report(index.html) which can be sent via email is generated in "html-report" folder:
 12. For debugging test cases add debug points, the press CNTRL+SHIFT+P and type "debug:debug npm script", on the edit box select desired script.
 13. Screenshots, Videos and Trace files will be generated in test-results folder.
-14. To change your username go to `testConfig.ts` and provide value against `username`
-15. To change password, go to `lib/WebActions` in `decipherPassword()` uncomment `ENCRYPT` code block and replace `password` with your password, execute the test case, Encrypted password will be printed on your console . Copy Encrypted password in `testConfig.ts` against `password` field. You can comment Encrypt bloack ater this.
-16. For executing Postgres DB test case, navigate to `testConfig.ts` and provide values for `dbUsername, dbPassword, dbServerName, dbPort, dbName`. Refer to `tests/DB.test.ts` for connecting to DB and Firing a Query.
+14. Each application under `apps/` contains its own `testConfig.ts` file. Update the username inside the relevant application's `testConfig.ts`.
+15. To change password, go to `lib/WebActions` in `decipherPassword()` uncomment `ENCRYPT` code block and replace `password` with your password, execute the test case, Encrypted password will be printed on your console. Copy the encrypted password into the appropriate `testConfig.ts` for that application. You can comment the `ENCRYPT` block after this.
+16. For executing Postgres DB test case, navigate to the application's `testConfig.ts` and provide values for `dbUsername, dbPassword, dbServerName, dbPort, dbName`. Refer to `tests/DB.test.ts` for connecting to DB and Firing a Query.
 17. For viewing trace files, go to folder where `trace.zip` is generated and execute :
 ```JS
 npx playwright show-trace trace.zip

--- a/apps/app1/playwright.config.ts
+++ b/apps/app1/playwright.config.ts
@@ -1,4 +1,5 @@
-import baseConfig, { ENV, testConfig } from '../../playwright.config';
+import baseConfig, { ENV } from '../../playwright.config';
+import { testConfig } from './testConfig';
 import { PlaywrightTestConfig } from '@playwright/test';
 
 const config: PlaywrightTestConfig = {

--- a/apps/app1/testConfig.ts
+++ b/apps/app1/testConfig.ts
@@ -1,0 +1,14 @@
+export const testConfig = {
+    qa: `https://www.burnsmcd.com/`,
+    dev: ``,
+    qaApi: `https://reqres.in`,
+    devApi: ``,
+    username: `demouat@gmail.com`,
+    password: `U2FsdGVkX18/eMdsOJpvI4hJZ/w7hNgwSRFaDvAcZx4=`,
+    waitForElement: 120000,
+    dbUsername: ``,
+    dbPassword: ``,
+    dbServerName: ``,
+    dbPort: ``,
+    dbName: ``
+}

--- a/apps/app2/playwright.config.ts
+++ b/apps/app2/playwright.config.ts
@@ -1,4 +1,5 @@
-import baseConfig, { ENV, testConfig } from '../../playwright.config';
+import baseConfig, { ENV } from '../../playwright.config';
+import { testConfig } from './testConfig';
 import { PlaywrightTestConfig } from '@playwright/test';
 
 const config: PlaywrightTestConfig = {
@@ -16,5 +17,4 @@ const config: PlaywrightTestConfig = {
     ...(baseConfig.projects || []),
   ],
 };
-
 export default config;

--- a/apps/app2/testConfig.ts
+++ b/apps/app2/testConfig.ts
@@ -1,0 +1,15 @@
+export const testConfig = {
+    qa: `https://www.burnsmcd.com/`,
+    dev: ``,
+    qaApi: `https://reqres.in`,
+    devApi: ``,
+    username: `demouat@gmail.com`,
+    password: `U2FsdGVkX18/eMdsOJpvI4hJZ/w7hNgwSRFaDvAcZx4=`,
+    waitForElement: 120000,
+    dbUsername: ``,
+    dbPassword: ``,
+    dbServerName: ``,
+    dbPort: ``,
+    dbName: ``
+}
+


### PR DESCRIPTION
## Summary
- include standalone testConfig.ts files inside each app
- reference new configs from app-level Playwright configs
- document per-app config usage in README

## Testing
- `npm test` *(fails: registry access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_686ddcfb7314832a9296a1219d519915