### PR TITLE
Add app specific base tests

### DIFF
--- a/apps/app1/BaseTest.ts
+++ b/apps/app1/BaseTest.ts
@@ -1,0 +1,42 @@
+import base from '@lib/BaseTest';
+import { LoginPage } from '@pages/LoginPage';
+import { ElementsPage } from '@pages/ElementsPage';
+import { AlertsFrameWindowsPage } from '@pages/AlertsFrameWindowsPage';
+import { WidgetsPage } from '@pages/WidgetsPage';
+import { HomePage } from '@pages/HomePage';
+import { LocationsPage } from '@pages/Locations';
+import { InteractionsPage } from '@pages/InteractionsPage';
+
+const test = base.extend<{
+  loginPage: LoginPage;
+  locationPage: LocationsPage;
+  elementsPage: ElementsPage;
+  alertsFrameWindowsPage: AlertsFrameWindowsPage;
+  widgetsPage: WidgetsPage;
+  interactionsPage: InteractionsPage;
+  homePage: HomePage;
+}>({
+  homePage: async ({ page, context }, use) => {
+    await use(new HomePage(page, context));
+  },
+  loginPage: async ({ page, context }, use) => {
+    await use(new LoginPage(page, context));
+  },
+  locationPage: async ({ page, context }, use) => {
+    await use(new LocationsPage(page, context));
+  },
+  elementsPage: async ({ page, context }, use) => {
+    await use(new ElementsPage(page, context));
+  },
+  alertsFrameWindowsPage: async ({ page, context }, use) => {
+    await use(new AlertsFrameWindowsPage(page, context));
+  },
+  widgetsPage: async ({ page, context }, use) => {
+    await use(new WidgetsPage(page, context));
+  },
+  interactionsPage: async ({ page, context }, use) => {
+    await use(new InteractionsPage(page, context));
+  },
+});
+
+export default test;

--- a/apps/app1/tests/accessibility/Axe.test.ts
+++ b/apps/app1/tests/accessibility/Axe.test.ts
@@ -1,9 +1,8 @@
-import test from '@lib/BaseTest';
+import test from '@app1Base';
 import { expect } from "@playwright/test";
 
 test(`Verify Page Accessibility`, async ({ page, makeAxeBuilder }) => {
     await page.goto('https://www.burnsmcd.com/');
     const accessibilityScanResults = await makeAxeBuilder.analyze();
     // Automatically uses the shared AxeBuilder configuration,
-    expect(accessibilityScanResults.violations).toEqual([]);
-});
+    expect(accessibilityScanResults.violations).toEqual([]);});

--- a/apps/app1/tests/api/GET.test.ts
+++ b/apps/app1/tests/api/GET.test.ts
@@ -1,5 +1,5 @@
 import { APIActions } from '@lib/APIActions';
-import { test } from '@playwright/test';
+import test from '@app1Base';
 
 const apiActions = new APIActions();
 

--- a/apps/app1/tests/api/POST.test.ts
+++ b/apps/app1/tests/api/POST.test.ts
@@ -1,5 +1,5 @@
 import { APIActions } from '@lib/APIActions';
-import { test } from '@playwright/test';
+import test from '@app1Base';
 
 const apiActions = new APIActions();
 

--- a/apps/app1/tests/db/DB.test.ts
+++ b/apps/app1/tests/db/DB.test.ts
@@ -1,5 +1,6 @@
 import { DBActions } from '@lib/DBActions';
-import { test, expect } from '@playwright/test'
+import test from '@app1Base'
+import { expect } from '@playwright/test'
 
 test('SQLite DB demo', async () => {
     const db = new DBActions();
@@ -12,5 +13,4 @@ test('SQLite DB demo', async () => {
     expect(row.id).toBe(1);
     expect(row.name).toBe('Playwright');
 
-    await db.close();
-});
+    await db.close();});

--- a/apps/app1/tests/devices/Emulation.test.ts
+++ b/apps/app1/tests/devices/Emulation.test.ts
@@ -1,8 +1,7 @@
-import test from '@lib/BaseTest';
+import test from '@app1Base';
 
 test(`Verify Elements Page.`, async ({ loginPage, elementsPage, webActions }) => {
     await loginPage.navigateToURL();
     await webActions.clickByText('Elements'); // Click on Elements Icon identified via text selector
     await webActions.clickByText('Text Box'); //Click on TextBox Navigation Sidebar identified via text selector
-    await elementsPage.enterFullName(`AutoTest`);
-});
+    await elementsPage.enterFullName(`AutoTest`);});

--- a/apps/app1/tests/functional/AlertsFrameWindows.test.ts
+++ b/apps/app1/tests/functional/AlertsFrameWindows.test.ts
@@ -1,4 +1,4 @@
-import test from '@lib/BaseTest';
+import test from '@app1Base';
 
 test(`Verify Alerts, Frame & Windows Page`, { tag: '@Smoke'}, async ({ loginPage, alertsFrameWindowsPage, webActions }) => {
     await loginPage.navigateToURL();
@@ -11,5 +11,4 @@ test(`Verify Alerts, Frame & Windows Page`, { tag: '@Smoke'}, async ({ loginPage
     await webActions.clickByText('Frames');
     await alertsFrameWindowsPage.verifyFrameText('This is a sample page');
     await webActions.clickByText('Nested Frames');
-    await alertsFrameWindowsPage.verifyNestedFrameChildText();
-});
+    await alertsFrameWindowsPage.verifyNestedFrameChildText();});

--- a/apps/app1/tests/functional/Burns/BurnsMcDonnellHeaderFooter.test.ts
+++ b/apps/app1/tests/functional/Burns/BurnsMcDonnellHeaderFooter.test.ts
@@ -1,4 +1,4 @@
-import test from '@lib/BaseTest';
+import test from '@app1Base';
 
 test('Burns and McDonnell Validate Header Footer', async ({ homePage }) => {
   await homePage.navigateToURL();

--- a/apps/app1/tests/functional/Burns/BurnsMcDonnellLocation.test.ts
+++ b/apps/app1/tests/functional/Burns/BurnsMcDonnellLocation.test.ts
@@ -1,4 +1,4 @@
-import test from '@lib/BaseTest';
+import test from '@app1Base';
 
 test('SCRUM-T1 Burns and McDonnell Validate Header Footer', async ({ homePage, locationPage }) => {
   await homePage.navigateToURL();

--- a/apps/app1/tests/functional/BurnsMcDonnellSearchProjects.test.ts
+++ b/apps/app1/tests/functional/BurnsMcDonnellSearchProjects.test.ts
@@ -1,4 +1,5 @@
-import { test, expect } from '@playwright/test';
+import test from '@app1Base';
+import { expect } from '@playwright/test';
 
 // Automation script: Search for 'project' and verify first five links
 

--- a/apps/app1/tests/functional/BurnsMcDonnellServicesLinks.test.ts
+++ b/apps/app1/tests/functional/BurnsMcDonnellServicesLinks.test.ts
@@ -1,4 +1,5 @@
-import { test, expect } from '@playwright/test';
+import test from '@app1Base';
+import { expect } from '@playwright/test';
 
 // Automation script: Navigate to 'What We Do' > 'Services' and validate all service links
 

--- a/apps/app1/tests/functional/Elements.test.ts
+++ b/apps/app1/tests/functional/Elements.test.ts
@@ -1,4 +1,4 @@
-import test from '@lib/BaseTest';
+import test from '@app1Base';
 
 test(`Verify Elements Page`, { tag: '@Smoke'}, async ({ loginPage, elementsPage, webActions }) => {
     await loginPage.navigateToURL();

--- a/apps/app1/tests/functional/HAR.test.ts
+++ b/apps/app1/tests/functional/HAR.test.ts
@@ -1,4 +1,4 @@
-import test from '@lib/BaseTest';
+import test from '@app1Base';
 
 test(`Generate and verify HAR file for Login Page.`, async ({ page, loginPage, webActions }) => {
     // To record HAR file use below line where "update:true"
@@ -12,5 +12,4 @@ test(`Generate and verify HAR file for Login Page.`, async ({ page, loginPage, w
     await webActions.clickByText('Book Store Application');
     await loginPage.clickOnLoginMainButton();
     await loginPage.loginToApplication();
-    await loginPage.verifyProfilePage();
-});
+    await loginPage.verifyProfilePage();});

--- a/apps/app1/tests/functional/Interactions.test.ts
+++ b/apps/app1/tests/functional/Interactions.test.ts
@@ -1,8 +1,7 @@
-import test from '@lib/BaseTest';
+import test from '@app1Base';
 
 test(`Verify Interactions Page`, { tag: '@Smoke'}, async ({ loginPage, interactionsPage, webActions }) => {
     await loginPage.navigateToURL();
     await webActions.clickByText('Interactions'); // Click on Interactions Icon identified via text selector
     await webActions.clickByText('Droppable');
-    await interactionsPage.verifyDragandDrop();
-});
+    await interactionsPage.verifyDragandDrop();});

--- a/apps/app1/tests/functional/Login.test.ts
+++ b/apps/app1/tests/functional/Login.test.ts
@@ -1,4 +1,4 @@
-import test from '@lib/BaseTest';
+import test from '@app1Base';
 
 // We can use Steps like in Cucmber format as shown below
 
@@ -17,5 +17,4 @@ test(`Verify Book Store Login`, { tag: '@Smoke'}, async ({ loginPage, webActions
     });
     await test.step(`Verify User is logged in and navigated to Profile page`, async () => {
         await loginPage.verifyProfilePage();
-    });
-}); 
+    });}); 

--- a/apps/app1/tests/functional/PdfToText.test.ts
+++ b/apps/app1/tests/functional/PdfToText.test.ts
@@ -1,8 +1,7 @@
-import test from '@lib/BaseTest';
+import test from '@app1Base';
 import { expect } from '@playwright/test';
 
 test(`Verify the text contents of PDF file.`, { tag: '@Smoke'}, async ({ webActions }) => {
     const extractedText = await webActions.getPDFText("./utils/functional/sample.pdf");
     const status = extractedText.includes("A Simple PDF File")
-    expect(status).toBeTruthy();
-});
+    expect(status).toBeTruthy();});

--- a/apps/app1/tests/functional/Widgets.test.ts
+++ b/apps/app1/tests/functional/Widgets.test.ts
@@ -1,4 +1,4 @@
-import test from '@lib/BaseTest';
+import test from '@app1Base';
 
 test(`Verify Widgets Page`, { tag: '@Smoke'}, async ({ loginPage, widgetsPage, webActions }) => {
     await loginPage.navigateToURL();
@@ -9,5 +9,4 @@ test(`Verify Widgets Page`, { tag: '@Smoke'}, async ({ loginPage, widgetsPage, w
     await webActions.clickByText('Tool Tips');
     await widgetsPage.verifyButtonTooltip('You hovered over the Button');
     await webActions.clickByText('Select Menu');
-    await widgetsPage.oldStyleSelectColour('Aqua');
-});
+    await widgetsPage.oldStyleSelectColour('Aqua');});

--- a/apps/app1/tests/visualComparison/visualComparision.test.ts
+++ b/apps/app1/tests/visualComparison/visualComparision.test.ts
@@ -1,6 +1,5 @@
-import test from '@lib/BaseTest';
+import test from '@app1Base';
 import { expect } from '@playwright/test';
 test(`Verify Elements Page.`, async ({ page, loginPage }) => {
     await loginPage.navigateToURL();
-    expect(await page.screenshot()).toMatchSnapshot('MainPage.png');
-});
+    expect(await page.screenshot()).toMatchSnapshot('MainPage.png');});

--- a/apps/app2/BaseTest.ts
+++ b/apps/app2/BaseTest.ts
@@ -1,0 +1,12 @@
+import base from '@lib/BaseTest';
+import { SamplePage } from '@app2pages/SamplePage';
+
+const test = base.extend<{
+  samplePage: SamplePage;
+}>({
+  samplePage: async ({}, use) => {
+    await use(new SamplePage());
+  },
+});
+
+export default test;

--- a/apps/app2/tests/sample.test.ts
+++ b/apps/app2/tests/sample.test.ts
@@ -1,4 +1,4 @@
-import test from '@playwright/test';
+import test from '@app2Base';
 import { SamplePage } from '@app2pages/SamplePage';
 
 // Sample placeholder test for app2

--- a/lib/BaseTest.ts
+++ b/lib/BaseTest.ts
@@ -1,49 +1,13 @@
-import { TestInfo, test as baseTest } from '@playwright/test';
-import { LoginPage } from '@pages/LoginPage';
-import { ElementsPage } from '@pages/ElementsPage';
-import { AlertsFrameWindowsPage } from '@pages/AlertsFrameWindowsPage';
-import { WidgetsPage } from '@pages/WidgetsPage';
-import { HomePage } from '@pages/HomePage';
-import { LocationsPage } from '@pages/Locations';
-import { InteractionsPage } from '@pages/InteractionsPage';
+import { test as baseTest } from '@playwright/test';
 import { WebActions } from '@lib/WebActions';
 import AxeBuilder from '@axe-core/playwright';
 
 const test = baseTest.extend<{
   webActions: WebActions;
-  loginPage: LoginPage;
-  locationPage: LocationsPage;
-  elementsPage: ElementsPage;
-  alertsFrameWindowsPage: AlertsFrameWindowsPage;
-  widgetsPage: WidgetsPage;
-  interactionsPage: InteractionsPage;
   makeAxeBuilder: AxeBuilder;
-  homePage: HomePage,
-  testInfo: TestInfo;
 }>({
   webActions: async ({ page, context }, use) => {
     await use(new WebActions(page, context));
-  },
-  homePage: async ({ page, context }, use) => {
-    await use(new HomePage(page, context));
-  },
-  loginPage: async ({ page, context }, use) => {
-    await use(new LoginPage(page, context));
-  },
-  locationPage: async ({ page, context }, use) => {
-    await use(new LocationsPage(page, context));
-  },
-  elementsPage: async ({ page, context }, use) => {
-    await use(new ElementsPage(page, context));
-  },
-  alertsFrameWindowsPage: async ({ page, context }, use) => {
-    await use(new AlertsFrameWindowsPage(page, context));
-  },
-  widgetsPage: async ({ page, context }, use) => {
-    await use(new WidgetsPage(page, context));
-  },
-  interactionsPage: async ({ page, context }, use) => {
-    await use(new InteractionsPage(page, context));
   },
   makeAxeBuilder: async ({ page }, use) => {
     await use(new AxeBuilder({ page })
@@ -51,5 +15,4 @@ const test = baseTest.extend<{
       .exclude('#commonly-reused-element-with-known-issue'));
   }
 })
-
 export default test;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,7 @@
       "@objects/*": ["apps/app1/pageFactory/objectRepository/*"],
       "@lib/*": ["lib/*"],
       "@shared/*": ["shared/*"],
-      "@app2pages/*": ["apps/app2/pageFactory/pageRepository/*"]
-    }
-  }}
+      "@app2pages/*": ["apps/app2/pageFactory/pageRepository/*"],
+      "@app1Base": ["apps/app1/BaseTest"],
+      "@app2Base": ["apps/app2/BaseTest"]
+    }  }}


### PR DESCRIPTION
## Summary
- refactor global BaseTest to include only shared fixtures
- add BaseTest for app1 with page object fixtures
- add BaseTest for app2
- alias app specific bases in tsconfig
- update tests to use new base aliases

## Testing
- `npx tsc -p apps/app1/tsconfig.json` *(fails: Cannot find global value 'Promise')*
- `npx tsc -p apps/app2/tsconfig.json` *(fails: Cannot find global value 'Promise')*
- `npx playwright test -c apps/app1/playwright.config.ts --list` *(fails: 403 Forbidden to registry.npmjs.org)*
- `npx playwright test -c apps/app2/playwright.config.ts --list` *(fails: 403 Forbidden to registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_686de386ab9c832a9b1e5c822d119959