### PR TITLE
Move path aliases to app-level tsconfigs

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,10 +195,11 @@ npm run allureReport
 npx playwright show-trace trace.zip
 ```
 18. You can change the Logging Message at Test Case/Test Step Level in CustomReporterConfig.ts file
-19. In `tsconfig.json` file in `paths` section we can re-assign the long path imports like '../../' to a variable which starts with '@' and then we can use it to shorten our import statements in respective file.
-In the below example wherever '../../apps/app1/pageFactory/pageRepository/' import statement is used we can replace it with '@pages'
+19. Module path aliases are defined in `tsconfig.base.json`. This base file specifies the shared mappings such as `@lib` and `@shared`.
+   Each application's `tsconfig.json` extends this file and adds its own paths. For example, `apps/app1/tsconfig.json` maps
+   `@pages` to its page repository:
 ```JS
-"@pages/*":["apps/app1/pageFactory/pageRepository/*"]
+"@pages/*": ["apps/app1/pageFactory/pageRepository/*"]
 ```
 20. Network Replay : 
 For using this featre in Playwright we use HAR file. 

--- a/apps/app1/tsconfig.json
+++ b/apps/app1/tsconfig.json
@@ -1,3 +1,12 @@
 {
-  "extends": "../../tsconfig.json"
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "paths": {
+      "@lib/*": ["lib/*"],
+      "@shared/*": ["shared/*"],
+      "@pages/*": ["apps/app1/pageFactory/pageRepository/*"],
+      "@objects/*": ["apps/app1/pageFactory/objectRepository/*"],
+      "@app1Base": ["apps/app1/BaseTest"]
+    }
+  }
 }

--- a/apps/app2/tsconfig.json
+++ b/apps/app2/tsconfig.json
@@ -1,3 +1,11 @@
 {
-  "extends": "../../tsconfig.json"
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "paths": {
+      "@lib/*": ["lib/*"],
+      "@shared/*": ["shared/*"],
+      "@app2pages/*": ["apps/app2/pageFactory/pageRepository/*"],
+      "@app2Base": ["apps/app2/BaseTest"]
+    }
+  }
 }

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "esModuleInterop": true,
+    "baseUrl": ".",
+    "paths": {
+      "@lib/*": ["lib/*"],
+      "@shared/*": ["shared/*"]
+    }
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,13 +1,13 @@
 {
+  "extends": "./tsconfig.base.json",
   "compilerOptions": {
-    "esModuleInterop": true,                             /*This is for "path" module import*/
-    "baseUrl": ".",                                      /* Specify the base directory to resolve non-relative module names. */
     "paths": {
       "@pages/*": ["apps/app1/pageFactory/pageRepository/*"],
       "@objects/*": ["apps/app1/pageFactory/objectRepository/*"],
-      "@lib/*": ["lib/*"],
-      "@shared/*": ["shared/*"],
       "@app2pages/*": ["apps/app2/pageFactory/pageRepository/*"],
-      "@app1Base": ["apps/app1/BaseTest"],
-      "@app2Base": ["apps/app2/BaseTest"]
-    }  }}
+      "@app1Base": ["apps/app1/BaseTest"],      "@app2Base": ["apps/app2/BaseTest"],
+      "@lib/*": ["lib/*"],
+      "@shared/*": ["shared/*"]
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- create a shared `tsconfig.base.json` with common compiler options
- extend the new base config from the root and application configs
- define application-specific path mappings in each app's tsconfig
- document the new base config in the README

## Testing
- `npx playwright --version` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_686de678334c832a9a6abbd2dd854735