### PR TITLE
Add integration test setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,6 +250,9 @@ npm run test:ui --ENV="qa"
 27. For Configuring Ortoni HTML Report, navigate to "playwright.config.ts" and provide desired changes "reportConfig" variable, then pass this variable in reporter section as ,['ortoni-report', reportConfig]. For more details on this please refer below video
 <a>https://www.youtube.com/watch?v=HMaiL6cARZk</a>
 
+28. Integration tests using page objects from both applications live in
+    `integration-tests/`. Run them with `npm run test:integration`.
+
 ## Reports
 
 - <b>Overall Report</b>

--- a/integration-tests/BaseTest.ts
+++ b/integration-tests/BaseTest.ts
@@ -1,0 +1,17 @@
+import base from '@lib/BaseTest';
+import { HomePage } from '@pages/HomePage';
+import { SamplePage } from '@app2pages/SamplePage';
+
+const test = base.extend<{
+  homePage: HomePage;
+  samplePage: SamplePage;
+}>({
+  homePage: async ({ page, context }, use) => {
+    await use(new HomePage(page, context));
+  },
+  samplePage: async ({}, use) => {
+    await use(new SamplePage());
+  },
+});
+
+export default test;

--- a/integration-tests/package.json
+++ b/integration-tests/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "integration-tests",
+  "private": true,
+  "scripts": {
+    "test": "npx playwright test -c playwright.config.ts --project=integration-chrome"
+  }
+}

--- a/integration-tests/playwright.config.ts
+++ b/integration-tests/playwright.config.ts
@@ -1,0 +1,21 @@
+import baseConfig, { ENV } from '../playwright.config';
+import { testConfig } from '../testConfig';
+import { PlaywrightTestConfig } from '@playwright/test';
+
+const config: PlaywrightTestConfig = {
+  ...baseConfig,
+  projects: [
+    {
+      name: 'integration-chrome',
+      testDir: './tests',
+      use: {
+        ...baseConfig.use,
+        browserName: 'chromium',
+        baseURL: testConfig[ENV],
+      },
+    },
+    ...(baseConfig.projects || []),
+  ],
+};
+
+export default config;

--- a/integration-tests/tests/app1App2Flow.test.ts
+++ b/integration-tests/tests/app1App2Flow.test.ts
@@ -1,0 +1,7 @@
+import test from '../BaseTest';
+
+test('integration flow using both apps', async ({ homePage, samplePage }) => {
+  await homePage.navigateToURL();
+  await homePage.verifyLogoExists();
+  await samplePage.placeholder();
+});

--- a/integration-tests/tsconfig.json
+++ b/integration-tests/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../tsconfig.base.json",
+  "compilerOptions": {
+    "paths": {
+      "@pages/*": ["../apps/app1/pageFactory/pageRepository/*"],
+      "@app2pages/*": ["../apps/app2/pageFactory/pageRepository/*"],
+      "@lib/*": ["../lib/*"]
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "test:accessibility": "npx playwright test Axe.test.ts --project=Chrome",
     "test:app1": "npx playwright test -c apps/app1/playwright.config.ts",
     "test:app2": "npx playwright test -c apps/app2/playwright.config.ts"
+    ,"test:integration": "npx playwright test -c integration-tests/playwright.config.ts"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary
- create `integration-tests` folder for cross-app flows
- register page objects from app1 and app2
- add sample integration test and Playwright config
- expose npm script and document in README

## Testing
- `npm run test:integration -- --list` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_686df6f1544c832a9df9f81c7bc85c41